### PR TITLE
fix: duplicate initialization of definiteMackData in multi-threads

### DIFF
--- a/vite-plugin-mock-dev-server/src/helper/defineMockData.ts
+++ b/vite-plugin-mock-dev-server/src/helper/defineMockData.ts
@@ -58,10 +58,18 @@ export function defineMockData<T = any>(
   key: string,
   initialData: T,
 ): MockData<T> {
-  if (!mockDataCache.has(key))
-    mockDataCache.set(key, new CacheImpl(initialData))
-
-  const cache = mockDataCache.get(key)! as CacheImpl<T>
+  let cache = mockDataCache.get(key) as CacheImpl<T> | undefined
+  if (!cache) {
+    const newCache = new CacheImpl(initialData)
+    const existing = mockDataCache.get(key)
+    if (existing) {
+      cache = existing as CacheImpl<T>
+    }
+    else {
+      mockDataCache.set(key, newCache)
+      cache = newCache
+    }
+  }
 
   cache.hotUpdate(initialData)
 


### PR DESCRIPTION
并发请求条件下，`definiteMackData` 定义的数据会重复初始化，特别是初始化大量数据情况下容易重现。重复初始化导致数据不一致。

该 PR 通过初始化后再次检查，避免重写导致数据不一致问题。