### PR TITLE
fix: avoid consuming request stream before body parsing

### DIFF
--- a/vite-plugin-mock-dev-server/__tests__/mockMiddleware.spec.ts
+++ b/vite-plugin-mock-dev-server/__tests__/mockMiddleware.spec.ts
@@ -6,6 +6,7 @@
 import type { Connect } from 'vite'
 import type { Compiler } from '../src/compiler'
 import type { MockHttpItem, MockOptions } from '../src/types'
+import { Buffer } from 'node:buffer'
 import { describe, expect, it, vi } from 'vitest'
 import { createMockMiddleware } from '../src/mockHttp/middleware'
 
@@ -71,6 +72,65 @@ function createMockRequest(options: {
       listeners[event]?.forEach(cb => cb(...args))
       return true
     },
+    removeListener() { return this },
+    removeAllListeners() { return this },
+  } as unknown as Connect.IncomingMessage
+}
+
+function createEagerMultipartRequest(options: {
+  url: string
+  method: string
+  headers: Record<string, string>
+  body: Buffer
+}): Connect.IncomingMessage {
+  const listeners: Record<string, Listener[]> = {}
+  let drained = false
+  let ended = false
+
+  function emit(event: string, ...args: any[]) {
+    listeners[event]?.forEach(cb => cb(...args))
+  }
+
+  function drain() {
+    if (drained)
+      return
+
+    drained = true
+    emit('data', options.body)
+    ended = true
+    emit('end')
+  }
+
+  return {
+    url: options.url,
+    method: options.method,
+    headers: options.headers,
+    socket: { encrypted: false },
+    connection: { encrypted: false },
+    addListener(event: string, callback: Listener) {
+      if (!listeners[event])
+        listeners[event] = []
+      listeners[event].push(callback)
+
+      if (event === 'data')
+        drain()
+      else if (event === 'end' && ended)
+        callback()
+
+      return this
+    },
+    on(event: string, callback: Listener) {
+      return (this as any).addListener(event, callback)
+    },
+    once(event: string, callback: Listener) {
+      return (this as any).addListener(event, callback)
+    },
+    emit(event: string, ...args: any[]) {
+      emit(event, ...args)
+      return true
+    },
+    pause() { return this },
+    resume() { return this },
     removeListener() { return this },
     removeAllListeners() { return this },
   } as unknown as Connect.IncomingMessage
@@ -221,6 +281,56 @@ describe('mockMiddleware', () => {
 
     expect(res.statusCode).toBe(201)
     expect(JSON.parse(res.data)).toEqual({ success: true })
+  })
+
+  it('should parse multipart body when request recovery collects the stream', async () => {
+    const boundary = '----mock-dev-server-test-boundary'
+    const rawBody = Buffer.from([
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename="test.txt"',
+      'Content-Type: text/plain',
+      '',
+      'hello',
+      `--${boundary}--`,
+      '',
+    ].join('\r\n'))
+
+    const mockItem: MockHttpItem = {
+      url: '/api/upload',
+      method: 'POST',
+      body: request => ({ hasFile: Boolean(request.body?.file) }),
+      status: 200,
+      __filepath__: 'test.mock.ts',
+    } as MockHttpItem
+
+    const compiler = createMockCompiler({
+      '/api/upload': [mockItem],
+    })
+
+    const middleware = createMockMiddleware(compiler, {
+      proxies: ['/api'],
+      logger: mockLogger as any,
+      cors: false,
+      record: { enabled: false },
+      replay: false,
+    } as any)
+
+    const req = createEagerMultipartRequest({
+      url: '/api/upload',
+      method: 'POST',
+      headers: {
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+        'content-length': String(rawBody.byteLength),
+      },
+      body: rawBody,
+    })
+    const res = createMockResponse()
+    const next = vi.fn()
+
+    await middleware(req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(JSON.parse(res.data)).toEqual({ hasFile: true })
   })
 
   it('should handle URL with query parameters', async () => {

--- a/vite-plugin-mock-dev-server/__tests__/requestRecovery.spec.ts
+++ b/vite-plugin-mock-dev-server/__tests__/requestRecovery.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for request recovery
+ *
+ * 请求恢复测试
+ */
+import type { Connect, UserConfig } from 'vite'
+import { Buffer } from 'node:buffer'
+import { describe, expect, it, vi } from 'vitest'
+import { cacheRequestBody, recoverRequest } from '../src/mockHttp/requestRecovery'
+
+describe('requestRecovery', () => {
+  it('should write cached raw body to proxy request', () => {
+    const rawBody = Buffer.from('hello')
+    const req = {} as Connect.IncomingMessage
+    const proxyReq = {
+      headersSent: false,
+      writableEnded: false,
+      setHeader: vi.fn(),
+      write: vi.fn(),
+    }
+    const listeners: Record<string, (...args: any[]) => void> = {}
+    const proxy = {
+      on: vi.fn((event: string, callback: (...args: any[]) => void) => {
+        listeners[event] = callback
+      }),
+    }
+    const config = {
+      server: {
+        proxy: {
+          '/api': { target: 'http://example.com' },
+        },
+      },
+    } as UserConfig
+
+    cacheRequestBody(req, rawBody)
+    recoverRequest(config)
+
+    const proxyOptions = config.server!.proxy!['/api'] as any
+    proxyOptions.configure(proxy, proxyOptions)
+    listeners.proxyReq(proxyReq, req)
+
+    expect(proxyReq.setHeader).toHaveBeenCalledWith('Content-Length', rawBody.byteLength)
+    expect(proxyReq.write).toHaveBeenCalledWith(rawBody)
+  })
+})

--- a/vite-plugin-mock-dev-server/src/mockHttp/middleware.ts
+++ b/vite-plugin-mock-dev-server/src/mockHttp/middleware.ts
@@ -17,11 +17,11 @@ import { createCors } from './cors'
 import { findMockData } from './matcher'
 import { matchingWeight } from './matchingWeight'
 import {
-  parseRequestBody,
+  parseRequestBodyWithRaw,
   parseRequestParams,
   requestLog,
 } from './request'
-import { collectRequest } from './requestRecovery'
+import { cacheRequestBody } from './requestRecovery'
 import {
   provideResponseCookies,
   provideResponseHeaders,
@@ -96,11 +96,9 @@ export function createMockMiddleware(
       return next()
     }
 
-    // #52 由于请求流被消费，vite http-proxy 无法获取已消费的请求，导致请求流无法继续
-    // 记录请求流中被消费的数据，形成备份，当当前请求无法继续时，可以从备份中恢复请求流
-    collectRequest(req)
-
     const cookies = new Cookies(req, res, cookiesOptions)
+    const { body: parsedBody, rawBody } = await parseRequestBodyWithRaw(req, logger, formidableOptions, bodyParserOptions)
+    cacheRequestBody(req, rawBody)
 
     let mock: MockHttpItem | undefined
     let _mockUrl: string | undefined
@@ -109,7 +107,7 @@ export function createMockMiddleware(
     const extraReq: Omit<ExtraRequest, 'params'> = {
       query,
       refererQuery: req.headers.referer ? urlParse(req.headers.referer).query : {},
-      body: await parseRequestBody(req, logger, formidableOptions, bodyParserOptions),
+      body: parsedBody,
       headers: req.headers,
       getCookie: cookies.get.bind(cookies),
     }

--- a/vite-plugin-mock-dev-server/src/mockHttp/request.ts
+++ b/vite-plugin-mock-dev-server/src/mockHttp/request.ts
@@ -2,6 +2,8 @@ import type { MatchFunction } from 'path-to-regexp'
 import type { Connect } from 'vite'
 import type { Logger } from '../core'
 import type { BodyParserOptions, ExtraRequest, MockRequest } from '../types'
+import { Buffer } from 'node:buffer'
+import { PassThrough } from 'node:stream'
 import { isEmptyObject } from '@pengzhanbo/utils'
 import ansis from 'ansis'
 import bodyParser from 'co-body'
@@ -60,6 +62,78 @@ export async function parseRequestBody(
     logger.error(e)
   }
   return undefined
+}
+
+export interface ParsedRequestBody {
+  body: any
+  rawBody?: Buffer
+}
+
+/**
+ * Parse request body and collect raw body
+ *
+ * 解析请求体并收集原始请求体
+ *
+ * @param req - Incoming message object / 入站消息对象
+ * @param logger - Logger instance / 日志实例
+ * @param formidableOptions - Formidable options for multipart form data / 用于 multipart 表单数据的 Formidable 配置项
+ * @param bodyParserOptions - Body parser options / 请求体解析配置项
+ * @returns Parsed request body and raw request body / 解析后的请求体和原始请求体
+ */
+export async function parseRequestBodyWithRaw(
+  req: Connect.IncomingMessage,
+  logger: Logger,
+  formidableOptions: formidable.Options,
+  bodyParserOptions: BodyParserOptions = {},
+): Promise<ParsedRequestBody> {
+  const method = req.method!.toUpperCase()
+  if (['HEAD', 'OPTIONS'].includes(method))
+    return { body: undefined }
+
+  const contentType = req.headers['content-type']
+  const contentLength = req.headers['content-length']
+  const transferEncoding = req.headers['transfer-encoding']
+  if (!contentType && !contentLength && !transferEncoding)
+    return { body: undefined }
+
+  const rawBody = await readRequestBody(req)
+  if (!rawBody.byteLength)
+    return { body: undefined, rawBody }
+
+  const body = await parseRequestBody(
+    createRequestStream(req, rawBody),
+    logger,
+    formidableOptions,
+    bodyParserOptions,
+  )
+
+  return { body, rawBody }
+}
+
+function readRequestBody(req: Connect.IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+
+    req.on('error', reject)
+    req.on('end', () => {
+      resolve(chunks.length ? Buffer.concat(chunks) : Buffer.alloc(0))
+    })
+    req.on('data', (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    })
+  })
+}
+
+function createRequestStream(req: Connect.IncomingMessage, rawBody: Buffer): Connect.IncomingMessage {
+  const stream = new PassThrough()
+  Object.assign(stream, {
+    headers: req.headers,
+    method: req.method,
+    url: req.url,
+    socket: req.socket,
+  })
+  stream.end(rawBody)
+  return stream as unknown as Connect.IncomingMessage
 }
 
 /**

--- a/vite-plugin-mock-dev-server/src/mockHttp/requestRecovery.ts
+++ b/vite-plugin-mock-dev-server/src/mockHttp/requestRecovery.ts
@@ -20,6 +20,19 @@ import { isString, objectKeys } from '@pengzhanbo/utils'
 const cache = new WeakMap<Connect.IncomingMessage, Buffer>()
 
 /**
+ * Cache request body
+ *
+ * 缓存请求体数据
+ *
+ * @param req - Incoming message / 入站消息
+ * @param body - Raw request body / 原始请求体
+ */
+export function cacheRequestBody(req: Connect.IncomingMessage, body?: Buffer): void {
+  if (body?.byteLength)
+    cache.set(req, body)
+}
+
+/**
  * Collect request data
  *
  * 备份请求数据


### PR DESCRIPTION
## Summary

This PR fixes an intermittent multipart parsing issue caused by consuming the same request stream twice.

Previously, `collectRequest(req)` attached `data` / `end` listeners before `parseRequestBody(req)` parsed the body. For multipart requests, this could switch the `IncomingMessage` into flowing mode before `formidable` attached its parser, causing valid multipart requests to be parsed as an empty object intermittently.

The fix makes request body parsing and proxy recovery share a single read path:

- Read the original request stream once.
- Parse the body from a cloned stream.
- Cache the same raw body buffer for proxy request recovery.
- Avoid attaching competing listeners to the original request stream.

## Problem

The old middleware flow was:

```ts
collectRequest(req)

const extraReq = {
  body: await parseRequestBody(req, ...),
}
```

Both `collectRequest` and `parseRequestBody` consumed the same `IncomingMessage` stream.

For `multipart/form-data`, this could result in `formidable` receiving an already-drained stream. In that case, the request still had a valid `Content-Length`, but the parsed body could be `{}`.

## Changes

- Added `parseRequestBodyWithRaw`.
- Added `cacheRequestBody`.
- Updated middleware to parse and collect raw body through one unified path.
- Kept proxy fallback behavior by reusing the collected raw body.
- Added a regression test that reproduces the multipart stream-consumption issue.
- Added a request recovery test to ensure cached raw body is written back to proxy requests.

## Tests

Added coverage for:

- Multipart body parsing when request recovery also needs the stream.
- Proxy request recovery using the cached raw body.

Verified with:

```bash
pnpm test
pnpm lint
```

## Before This Fix

The new regression test fails with the previous implementation:

```txt
expected { hasFile: false } to deeply equal { hasFile: true }
```

This confirms that the file field is lost when `collectRequest(req)` consumes the stream before `formidable`.

## After This Fix

The same test passes because the original request stream is consumed only once, then reused for both body parsing and proxy recovery.
