### PR TITLE
feat: add npm bugs metadata to `package.json`

### DIFF
--- a/vite-plugin-mock-dev-server/package.json
+++ b/vite-plugin-mock-dev-server/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "git+https://github.com/pengzhanbo/vite-plugin-mock-dev-server"
   },
+  "bugs": {
+    "url": "https://github.com/pengzhanbo/vite-plugin-mock-dev-server/issues"
+  },
   "keywords": [
     "vite",
     "plugin",


### PR DESCRIPTION
## Summary

Add standard npm `bugs` metadata to `vite-plugin-mock-dev-server/package.json`.

The published `vite-plugin-mock-dev-server@2.4.0` package exposes `homepage` and `repository` metadata, but npm metadata does not expose a `bugs` field. This change points package consumers and automated tooling to the public issue tracker.

## Validation

- Direct npm registry metadata check for `vite-plugin-mock-dev-server@2.4.0`
- `node -e "const p=require('./vite-plugin-mock-dev-server/package.json'); if(!p.bugs?.url?.includes('pengzhanbo/vite-plugin-mock-dev-server/issues')) throw new Error('bugs mismatch'); console.log(JSON.stringify({name:p.name,homepage:p.homepage,repository:p.repository,bugs:p.bugs}, null, 2));"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts` from `vite-plugin-mock-dev-server`

## Scope

Manifest metadata only. No runtime code, dependency, or lockfile changes.
