### PR TITLE
fix: fix incorrectly merge `req.headers` data into `request`

### DIFF
--- a/vite-plugin-mock-dev-server/src/mockHttp/middleware.ts
+++ b/vite-plugin-mock-dev-server/src/mockHttp/middleware.ts
@@ -8,7 +8,7 @@ import type {
   MockRequest,
   MockResponse,
 } from '../types'
-import { attemptAsync, isFunction, isNil, timestamp, toArray } from '@pengzhanbo/utils'
+import { attemptAsync, isFunction, isNil, omit, timestamp, toArray } from '@pengzhanbo/utils'
 import ansis from 'ansis'
 import Cookies from 'cookies'
 import { recordRequestWithRawReq, replayRecordedRequest } from '../recorder'
@@ -157,12 +157,7 @@ export function createMockMiddleware(
     const response = res as MockResponse
 
     // provide request 往请求实例中注入额外的请求信息
-    Object.assign(request, {
-      query: extraReq.query,
-      refererQuery: extraReq.refererQuery,
-      body: extraReq.body,
-      getCookie: extraReq.getCookie,
-    })
+    Object.assign(request, omit(extraReq, ['headers']))
     request.params = parseRequestParams(mock.url, pathname)
 
     // provide response

--- a/vite-plugin-mock-dev-server/src/mockHttp/middleware.ts
+++ b/vite-plugin-mock-dev-server/src/mockHttp/middleware.ts
@@ -157,7 +157,12 @@ export function createMockMiddleware(
     const response = res as MockResponse
 
     // provide request 往请求实例中注入额外的请求信息
-    Object.assign(request, extraReq)
+    Object.assign(request, {
+      query: extraReq.query,
+      refererQuery: extraReq.refererQuery,
+      body: extraReq.body,
+      getCookie: extraReq.getCookie,
+    })
     request.params = parseRequestParams(mock.url, pathname)
 
     // provide response


### PR DESCRIPTION
see issue https://github.com/pengzhanbo/vite-plugin-mock-dev-server/issues/157

fix for  when using node26 & h2 enabled dev server
TypeError: Cannot set property headers of # which has only a getter
at Object.assign ()
at file:///Users/js36fe/Developer/P26049-IHB/frontend/node_modules/vite-plugin-mock-dev-server/dist/server-BZ7OOeu3.js:2:3273
at process.processTicksAndRejections (node:internal/process/task_queues:104:5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化 Mock 服务器的请求信息注入策略：构建注入数据时排除 headers，仅显式注入必要字段（query、refererQuery、body、getCookie），避免不必要字段覆盖，提升 mock 的准确性与可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->