### PR TITLE
fix: fix virtual module being mistakenly identified as internal module, close #161

### DIFF
--- a/vite-plugin-mock-dev-server/src/compiler/rolldown.ts
+++ b/vite-plugin-mock-dev-server/src/compiler/rolldown.ts
@@ -89,7 +89,7 @@ export async function transformWithRolldown(
     return {
       code: result.output[0].code,
       internalDeps: result.output[0].moduleIds
-        .filter(id => !id.endsWith(filename))
+        .filter(id => !id.endsWith(filename) && !id.startsWith('\0'))
         .map(id => normalizePath(path.relative(cwd, id))),
       externalDeps: [...result.output[0].imports, ...result.output[0].dynamicImports],
     }


### PR DESCRIPTION
resolve #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复开发环境构建过程中内部模块依赖识别不准确的问题，避免特殊模块标识被错误纳入依赖列表。
  * 提升相关模块处理的稳定性，外部依赖收集行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->